### PR TITLE
Add a proper description to show on the Paypal order page

### DIFF
--- a/lib/shoppe/paypal/order_extensions.rb
+++ b/lib/shoppe/paypal/order_extensions.rb
@@ -16,7 +16,7 @@ module Shoppe
             :amount => {
               :total => '%.2f' % self.total,
               :currency => Shoppe::Paypal.currency },
-            :description => "Order #{self.number}" } ] } )
+            :description => "Total: #{ '%.2f' % self.total }#{Shoppe::Paypal.currency} for Order #{self.number}" } ] } )
 
         if @payment.create
           @payment.links.find{|v| v.method == "REDIRECT" }.href


### PR DESCRIPTION
By default, when the user is taken to the Paypal site, there is no reference given to the amount they will be charged. This change ensures that the total amount is shown to the user at every step on the Paypal site by referencing the total amount due in the transaction description.
